### PR TITLE
Moved GitHub banner from left to right, so it doesn't occlude the UI

### DIFF
--- a/template.php
+++ b/template.php
@@ -24,8 +24,8 @@
 		<meta name="distribution" content="global">
 		<meta name="rating" content="general">
 
-    </HEAD>
-    <BODY>
+    </head>
+    <body>
       <div class="mitte" id="overall">
         <a href="/"><div id="header">
             <div style="padding:15px;"><div class="rechts"><?php echo $slogan; ?></div></div>
@@ -38,5 +38,5 @@
       </div>
       
       <a href="https://github.com/chrisiaut/pictshare"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
-    </BODY>
-</HTML>
+  </body>
+</html>

--- a/template.php
+++ b/template.php
@@ -37,6 +37,6 @@
         <div id="footer"></div>
       </div>
       
-      <a href="https://github.com/chrisiaut/pictshare"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://camo.githubusercontent.com/82b228a3648bf44fc1163ef44c62fcc60081495e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_red_aa0000.png"></a>
+      <a href="https://github.com/chrisiaut/pictshare"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     </BODY>
 </HTML>


### PR DESCRIPTION
By default, the GitHub banner in the template occludes the UI. See: 

![Screen Shot](http://i.imgur.com/azMy1m6.png)

I moved it to the right, so it no longer occludes the UI. See:

![Fixed Screen shot](http://i.imgur.com/naiwy5H.png)

While I was at it, I normalized the case of the HTML.