### PR TITLE
PHP overriding caching

### DIFF
--- a/backend.php
+++ b/backend.php
@@ -1,4 +1,7 @@
 <?php	
+session_cache_limiter("public");
+$expiry = 90; //days
+session_cache_expire($expiry * 24 * 60);
 session_start();
 define('DS', DIRECTORY_SEPARATOR);
 define('ROOT', dirname(__FILE__));

--- a/index.php
+++ b/index.php
@@ -1,4 +1,7 @@
 <?php
+session_cache_limiter("public");
+$expiry = 90; //days
+session_cache_expire($expiry * 24 * 60);
 session_start();
 define('DS', DIRECTORY_SEPARATOR);
 define('ROOT', dirname(__FILE__));


### PR DESCRIPTION
I noticed that images uploaded to PictShare were never being cached by any browser.

I looked through the code, and saw in [inc/core.php](https://github.com/chrisiaut/pictshare/blob/master/inc/core.php), it is attempting to set the cache Expires header for images and videos to 90 days, but most PHP configs will override this and completely disable caching (Even if Pragma and Cache-Control are unset).

This happened on my personal server and on the [public site](https://www.pictshare.net/).

If I changed this setting on a global level, it broke other PHP pages, but setting PHP's cache_limiter to public does not seem to do any harm to PictShare, and images are cached now!