### PR TITLE
Adds 'Content-Type' header with 'application/json' value

### DIFF
--- a/backend.php
+++ b/backend.php
@@ -24,6 +24,8 @@ include_once(ROOT.DS.'inc'.DS.'core.php');
 
 $pm = new PictshareModel();
 
+header('Content-Type: application/json; charset=utf-8');
+
 if(UPLOAD_CODE!=false && !$pm->uploadCodeExists($_REQUEST['upload_code']))
 	exit(json_encode(array('status'=>'ERR','reason'=>'Wrong upload code provided')));
 


### PR DESCRIPTION
This PR adds `Content-Type` header with `application/json` value for all `backend.php` responses.

During integration of pictshare with my application I found, that all responses gotten from backend.php has `text/html; charset=utf-8` value. This is not valid behavior since every return value encoded to JSON, so header is necessary. It's also necessary because some response converters looks into this value and as a result they are confused (my case).