### PR TITLE
Fix PNG transparency in base64 backend upload

### DIFF
--- a/models/pictsharemodel.php
+++ b/models/pictsharemodel.php
@@ -748,6 +748,8 @@ class PictshareModel extends Model
 		break;
 	
 		case 'png':
+				imagefill($source, 0, 0, IMG_COLOR_TRANSPARENT);
+				imagesavealpha($source,true);
 				imagepng($source,$output_file,(defined('PNG_COMPRESSION')?PNG_COMPRESSION:6));
 				trigger_error("========= SAVING AS ".$type." TO ".$output_file);
 		break;
@@ -758,6 +760,8 @@ class PictshareModel extends Model
 		break;
 	
 		default:
+				imagefill($source, 0, 0, IMG_COLOR_TRANSPARENT);
+				imagesavealpha($source,true);
 				imagepng($source,$output_file,(defined('PNG_COMPRESSION')?PNG_COMPRESSION:6));
 		break;
 		}


### PR DESCRIPTION
Transparent background support added in https://github.com/chrisiaut/pictshare/commit/948088ae51121bd738bed1a06666ee6fea9ec29d currently works only for uploading from form. This PR adds support of it for base64 string images from backend endpoint too.