### PR TITLE
Fix MASTER_DELETE_CODE to work with deletion codes with uppercase letters

### DIFF
--- a/models/pictsharemodel.php
+++ b/models/pictsharemodel.php
@@ -104,11 +104,11 @@ class PictshareModel extends Model
 			}
 			else if($el=='forcesize')
 				$data['forcesize'] = true;
-			else if(strlen(MASTER_DELETE_CODE)>10 && $el=='delete_'.MASTER_DELETE_CODE)
+			else if(strlen(MASTER_DELETE_CODE)>10 && $el=='delete_'.strtolower(MASTER_DELETE_CODE))
 				$data['delete'] = true;
 			else if($el=='delete' && $this->mayDeleteImages()===true)
 				$data['delete'] = true;
-			else if((strlen(MASTER_DELETE_CODE)>10 && $el=='delete_'.MASTER_DELETE_CODE) || $this->deleteCodeExists($el))
+			else if((strlen(MASTER_DELETE_CODE)>10 && $el=='delete_'.strtolower(MASTER_DELETE_CODE)) || $this->deleteCodeExists($el))
 				$data['delete'] = $this->deleteCodeExists($el)?$el:true;
 				
 		}


### PR DESCRIPTION
Hello,

After about an hour of trying to figure out why my master delete code wasn't working, I discovered that the problem was that my master deletion code had uppercase characters. Deletion codes with uppercase characters are always rejected because each URL segment is [converted to lowercase](https://github.com/chrisiaut/pictshare/blob/master/models/pictsharemodel.php#L70) before being compared. My temporary solution was to just convert my code to lowercase.

The changes made in this PR will ensure that the MASTER_DELETE_CODE is converted to lowercase in the comparison, which will allow codes with uppercase letters to work.