### PR TITLE
Fix docker volumes path problem

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     restart: always
     image: hascheksolutions/pictshare:latest
     volumes:
-    - ./volumes/upload:/opt/pictshare/upload
+    - ./volumes/upload:/usr/share/nginx/html/upload
     ports:
     - "80:80"
     - "443:443"


### PR DESCRIPTION
The original path was wrong, the Pictshare upload files are stored in /usr/share/nginx/html/upload